### PR TITLE
feat: Página de aviso de privacidad

### DIFF
--- a/src/layouts/MainLayout/index.tsx
+++ b/src/layouts/MainLayout/index.tsx
@@ -1,0 +1,35 @@
+import React from "react";
+import {Route, RouteProps} from "react-router-dom";
+import {Header} from "src/theme/components/Header/Header";
+import styled from "styled-components";
+
+interface MainLayoutProps extends RouteProps {
+    component: any,
+    showPages: boolean,
+    showContent?: () => void
+}
+
+const MainLayout = ({ component: Component, showPages, showContent,  ...rest }: MainLayoutProps) => (
+    <>
+        <Header expanded={false} showContent={showContent}/>
+        {showPages &&
+        <PagesContainer>
+            <Route
+                {...rest}
+                render={(props) => (
+                    <Component {...props} />
+                )}
+            />
+        </PagesContainer>
+        }
+    </>
+);
+
+const PagesContainer = styled.div`
+  width: 100%;
+  height: 700px;
+
+  transition: all 1s;
+`
+
+export default MainLayout;

--- a/src/layouts/PageLayout/index.tsx
+++ b/src/layouts/PageLayout/index.tsx
@@ -1,0 +1,63 @@
+import React from "react";
+import {Route, RouteProps} from "react-router-dom";
+import {Header} from "src/theme/components/Header/Header";
+import styled from "styled-components";
+
+interface PageLayoutProps extends RouteProps {
+    component: any
+}
+
+const PageLayout = ({ component: Component,  ...rest }: PageLayoutProps) => (
+    <>
+        <Header expanded={true}/>
+        <Container>
+            <Box>
+                <Route
+                    {...rest}
+                    render={(props) => (
+                        <Component {...props} />
+                    )}
+                />
+            </Box>
+        </Container>
+    </>
+);
+
+const px2vw = (size: number, width: number = 1440) => `${(size / width) * 100}vw`;
+
+const Container = styled.div`
+  display: flex;
+  flex-wrap: wrap;
+  justify-content: center;
+  max-width: 100%;
+
+  @media (min-width: 1024px) {
+    flex-wrap: nowrap;
+  }
+`;
+
+const Box = styled.div`
+  display: flex;
+  width: ${px2vw(320, 320)};
+  min-height: ${px2vw(200, 320)};
+  flex-direction: column;
+  padding: ${px2vw(20)};
+  padding-top: 0;
+  margin: ${px2vw(20)};
+  height: 100%;
+
+  @media (min-width: 768px) {
+    width: ${px2vw(500, 768)};
+    min-height: ${px2vw(200, 768)};
+    height: 100%;
+  }
+
+  @media (min-width: 1024px) {
+    width: ${px2vw(800)};
+    min-height: ${px2vw(300)};
+    height: 100%;
+  }
+`;
+
+
+export default PageLayout;

--- a/src/pages/Home/InformativeSection.tsx
+++ b/src/pages/Home/InformativeSection.tsx
@@ -1,4 +1,5 @@
 import React from "react";
+import { Link } from "react-router-dom";
 import DIVIDER from "src/assets/images/register_divisor.png";
 import styled from "styled-components";
 import {LightText, RegularText} from "src/theme/styles/generalstyles/Text";
@@ -22,7 +23,7 @@ export const InformativeSection = () => {
             <CheckBoxContainer>
                 <CheckBox type={'checkbox'} />
                 <Label className="animated-fast fadeIn">
-                    Aceptar <strong>política de privacidad</strong> Ten seguro que tus datos estarán protegidos y nunca serán usados con un fin distinto a la organización digital.
+                    Aceptar <Link to="/aviso-privacidad"><strong>política de privacidad</strong></Link> Ten seguro que tus datos estarán protegidos y nunca serán usados con un fin distinto a la organización digital.
                 </Label>
             </CheckBoxContainer>
 

--- a/src/pages/Home/PrivacyPolicy.tsx
+++ b/src/pages/Home/PrivacyPolicy.tsx
@@ -1,0 +1,170 @@
+import React from "react";
+import styled from "styled-components";
+import {LightText} from "src/theme/styles/generalstyles/Text";
+
+export const PrivacyPolicy = () => {
+    return (
+        <InformativeSectionContainer className="animated slideInLeft">
+            <InformativeTitle className="animated-fast fadeIn">
+                Aviso de Privacidad
+            </InformativeTitle>
+
+            <p>
+              David Enríquez Casas, con domicilio en calle Plaza Carlos Pacheco número 5,
+              colonia Centro, Ciudad de México, demarcación Cuauhtémoc, código postal 06000,
+              en la Ciudad de México, y portal de internet <a href="https://www.facebook.com/proyectomigala">https://www.facebook.com/proyectomigala</a>;
+              es el responsable del uso y protección de tus datos personales para el padrón del Proyecto Migala,
+              y al respecto te debemos informar lo siguiente:
+            </p>
+
+            <b>¿Para qué fines utilizaremos tus datos personales?</b>
+
+            <p>Los datos personales que recabamos de ti, los utilizaremos para las siguientes finalidades que son necesarias para el funcionamiento del proyecto:</p>
+            <ul>
+                <li>Orientación política</li>
+                <li>Capacitación</li>
+                <li>Participación en grupos de trabajo</li>
+                <li>Postulación a responsabilidades</li>
+                <li>Trabajo operativo</li>
+                <li>Línea política</li>
+                <li>Representación</li>
+                <li>Responsabilidades como enlace</li>
+                <li>Responsabilidades de dirección</li>
+                <li>Votaciones internas</li>
+                <li>Inscripción a procesos de selección de candidaturas</li>
+                <li>Precandidaturas</li>
+                <li>Candidaturas</li>
+                <li>Ocupación de cargos públicos</li>
+            </ul>
+
+            <b>¿Qué datos personales utilizaremos para estos fines?</b>
+
+            <p>Para llevar a cabo las finalidades descritas en el presente aviso de privacidad, utilizaremos tus siguientes datos personales:</p>
+            <ul>
+                <li>Nombre</li>
+                <li>Clave única de Registro de Población (CURP)</li>
+                <li>Clave de elector</li>
+                <li>Sección Electoral</li>
+                <li>Género</li>
+                <li>Lugar de nacimiento</li>
+                <li>Fecha de nacimiento</li>
+                <li>Nacionalidad</li>
+                <li>Teléfono celular</li>
+                <li>Correo electrónico</li>
+                <li>Puesto o cargo que desempeñas en tu actividad laboral</li>
+                <li>Trayectoria educativa</li>
+                <li>Trayectoria política</li>
+                <li>Pasatiempos</li>
+                <li>Aficiones</li>
+                <li>Deportes que practicas</li>
+                <li>Datos de contacto</li>
+            </ul>
+
+            Los datos recopilados se alojan en el servicio de Amazon AWS.
+
+            <b>¿Cómo puedes acceder, rectificar o cancelar tus datos personales, u oponerte a su uso?</b>
+
+            <p>
+                Tienes derecho a conocer qué datos personales tenemos de ti, para qué los utilizamos y las
+                condiciones del uso que les damos (acceso). Asimismo, es tu derecho solicitar la corrección de
+                tu información personal en caso de que esté desactualizada, sea inexacta o incompleta (Rectificación);
+                que la eliminemos de nuestros registros o bases de datos cuando consideres que la misma no está siendo
+                utilizada adecuadamente (Cancelación); así como oponerse al uso de tus datos personales para fines
+                específicos (Oposición). Estos derechos se conocen como derechos ARCO.
+            </p>
+
+            <p>
+                Para el ejercicio de cualquiera de los derechos ARCO, deberás presentar la solicitud respectiva a
+                través de David Enríquez Casas, con domicilio para recibir notificaciones en Calle Plaza Carlos Pacheco número 5,
+                colonia Centro, Demarcación Cuauhtémoc, código postal 06000, Ciudad de México, correo electrónico padron.pmigala@gmail.com.
+                Para conocer el procedimiento y requisitos para el ejercicio de los derechos ARCO, ponemos a tu disposición el correo electrónico padron.pmigala@gmail.com.
+            </p>
+
+            <p>
+                Los datos de contacto de la persona responsables del manejo y almacenamiento de datos personales, que está a cargo de dar
+                trámite a las solicitudes de derechos ARCO, son los siguientes:
+            </p>
+
+            <ul>            
+                <li>Nombre de la persona responsable del padrón: David Enríquez Casas</li>
+                <li>Domicilio: calle Plaza Carlos Pacheco número 5, colonia Centro, Ciudad de México, demarcación Cuauhtémoc, código postal 06000, en la Ciudad de México.</li>
+                <li>Correo electrónico: padron.pmigala@gmail.com</li>
+            </ul>
+
+            <b>Tú puedes revocar el consentimiento para el uso de tus datos personales</b>
+
+            <p>
+                Puedes revocar el consentimiento que, en tu caso, nos hayas otorgado para el tratamiento de tus datos personales.
+                Sin embargo, es importante que tengas en cuenta que no en todos los casos podremos atender tu solicitud o concluir
+                el uso de forma inmediata, ya que es posible que por alguna obligación legal requiramos seguir tratando tus datos
+                personales. Asimismo, deberás considerar que, para ciertos fines, la revocación de tu consentimiento implicará que
+                no podrás seguir participando en las actividades del Proyecto Migala y por ende la conclusión de tu relación con nosotros.
+            </p>
+
+            <p>
+                Para revocar tu consentimiento deberás presentar una solicitud; así como para conocer el procedimiento y requisitos para la
+                revocación del consentimiento, ponemos a tu disposición el correo electrónico padron.pmigala@gmail.com
+            </p>
+
+            <b>¿Cómo puedes limitar el uso o divulgación de tu información personal?</b>
+
+            <p>
+                Con objeto de que puedas limitar el uso y divulgación de tu información personal, te solicitamos también escribir a 
+                nuestro correo electrónico, padron.pmigala@gmail.com.
+            </p>
+
+            <b>El uso de tecnologías de rastreo en nuestro registro</b>
+
+            <p>
+                Te informamos que en nuestro registro utilizamos cookies, web beacons u otras tecnologías, a través de las cuales es
+                posible monitorear tu comportamiento como usuario de internet, así como brindar un mejor servicio y experiencia al
+                responder el formulario. Los datos personales que se recaban a través de estas tecnologías, los utilizaremos para armonizar
+                la Construcción y organización del Proyecto Migala.
+            </p>
+
+            <p>
+                Los datos personales que obtenemos de estas tecnologías de rastreo son los siguientes:
+            </p>
+
+            <ul>
+                <li>Idioma preferido por el usuario</li>
+                <li>Región en la que se encuentra el usuario</li>
+                <li>Tipo de navegador del usuario</li>
+                <li>Tipo de sistema operativo del usuario</li>
+            </ul>
+
+            <p>
+                Para conocer la forma en que se pueden deshabilitar estas tecnologías, ponerse en contacto al correo padron.pmigala@gmail.com
+            </p>
+
+            <b>¿Cómo puedes conocer los cambios en este aviso de privacidad?</b>
+
+            <p>
+                El presente aviso de privacidad puede sufrir modificaciones, cambios o actualizaciones derivadas de nuevos requerimientos legales;
+                de nuestras propias necesidades de nuestra organización; de nuestras prácticas de privacidad; de cambios en nuestro modelo de trabajo, o por otras causas.
+            </p>
+
+            <p>
+                Nos comprometemos a informarte sobre los cambios que pueda sufrir el presente aviso de privacidad, a través de comunicado por correo electrónico.
+            </p>
+
+            <p>
+                El procedimiento a través del cual se llevarán a cabo las notificaciones sobre cambios o actualizaciones a través de comunicado por correo electrónico,
+                del cual se solicitará la confirmación.
+            </p>
+        </InformativeSectionContainer>
+    )
+}
+
+const InformativeSectionContainer = styled.div`
+  display: flex;
+  flex-flow: column;
+  height: 100%;
+  text-align: left;
+`;
+
+const InformativeTitle = styled(LightText)`
+  text-align: center;
+  font-size: calc(16px + 2vmin);
+  padding: 20px 0;
+`;

--- a/src/routers/index.tsx
+++ b/src/routers/index.tsx
@@ -1,10 +1,12 @@
 import React, {useEffect, useRef, useState} from "react";
-import {Route, Router, Switch} from "react-router-dom";
+import {Router, Switch} from "react-router-dom";
 import {createBrowserHistory} from "history";
-import {Header} from "src/theme/components/Header/Header";
 import {HomePage} from "src/pages/Home/HomePage";
+import {PrivacyPolicy} from "src/pages/Home/PrivacyPolicy";
 import styled from "styled-components";
 import {MainForm} from "src/pages/Form/MainForm";
+import MainLayout from "src/layouts/MainLayout";
+import PageLayout from "src/layouts/PageLayout";
 
 const history = createBrowserHistory();
 
@@ -35,17 +37,11 @@ export const MainRouter = () => {
         <MainContainer ref={mainContainer}>
             <Router history={history}>
                 <RouteContentContainer>
-                    <Header expanded={false} showContent={showContent}/>
-                    {showPages &&
-                    <PagesContainer>
-
-                        <Switch>
-                            <Route exact path="/form" component={MainForm}/>
-                            <Route path="/" component={HomePage}/>
-                        </Switch>
-
-                    </PagesContainer>
-                    }
+                    <Switch>
+                        <MainLayout exact path="/" component={HomePage} showPages={showPages} showContent={showContent} />
+                        <MainLayout exact path="/form" component={MainForm} showPages={showPages} showContent={showContent} />
+                        <PageLayout exact path="/aviso-privacidad" component={PrivacyPolicy} />
+                    </Switch>
                 </RouteContentContainer>
             </Router>
         </MainContainer>
@@ -65,11 +61,4 @@ const RouteContentContainer = styled.div`
   display: flex;
   flex-flow: column;
   justify-content: space-between;
-`
-
-const PagesContainer = styled.div`
-  width: 100%;
-  height: 700px;
-
-  transition: all 1s;
 `


### PR DESCRIPTION
Agregué el aviso de privacidad en la ruta `/aviso-privacidad` con los datos que vienen el en formulario de [typeform](https://g9u97w67rwp.typeform.com/to/fPX3mPdF) 

También agregué una carpeta de Layouts, con un `MainLayout` que muestra el header completo al cargar la página, y un `PageLayout` que muestra el header cerrado y es el que utilicé para la página de privacidad.

**¿Como probar?**
- Visita la ruta `/aviso-privacidad`, debe contener el aviso de privacidad que se muestra en el typeform.
- También la puedes visitar si das click el texto de "política de privacidad" que se muestra el inicio del formulario