### PR TITLE
Agregando dockerfile y configuración de nginx

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -1,0 +1,24 @@
+# node ignore
+desktop.ini
+
+/.git
+
+# dependencies
+/node_modules
+/.pnp
+.pnp.js
+
+
+# testing
+/coverage
+
+# production
+/build
+
+# misc
+.DS_Store
+
+npm-debug.log*
+yarn-debug.log*
+yarn-error.log*
+firebase-debug.log*

--- a/.nginx/config/default.conf
+++ b/.nginx/config/default.conf
@@ -1,0 +1,47 @@
+server {
+    listen       5000;
+    listen  [::]:5000;
+    server_name  localhost;
+
+    #charset koi8-r;
+    #access_log  /var/log/nginx/host.access.log  main;
+
+    location / {
+        root   /usr/share/nginx/html;
+        index  index.html index.htm;
+        try_files $uri $uri/ /index.html =404;
+    }
+
+    #error_page  404              /404.html;
+
+    # redirect server error pages to the static page /50x.html
+    #
+    #error_page   500 502 503 504  /50x.html;
+    #location = /50x.html {
+    #    root   /usr/share/nginx/html;
+    #}
+
+    # proxy the PHP scripts to Apache listening on 127.0.0.1:80
+    #
+    #location ~ \.php$ {
+    #    proxy_pass   http://127.0.0.1;
+    #}
+
+    # pass the PHP scripts to FastCGI server listening on 127.0.0.1:9000
+    #
+    #location ~ \.php$ {
+    #    root           html;
+    #    fastcgi_pass   127.0.0.1:9000;
+    #    fastcgi_index  index.php;
+    #    fastcgi_param  SCRIPT_FILENAME  /scripts$fastcgi_script_name;
+    #    include        fastcgi_params;
+    #}
+
+    # deny access to .htaccess files, if Apache's document root
+    # concurs with nginx's one
+    #
+    #location ~ /\.ht {
+    #    deny  all;
+    #}
+}
+

--- a/.nginx/templates/default.conf.template
+++ b/.nginx/templates/default.conf.template
@@ -1,0 +1,46 @@
+server {
+    listen       ${PORT};
+    listen  [::]:${PORT};
+    server_name  localhost;
+
+    #charset koi8-r;
+    #access_log  /var/log/nginx/host.access.log  main;
+
+    location / {
+        root   /usr/share/nginx/html;
+        index  index.html index.htm;
+        try_files $uri $uri/ /index.html =404;
+    }
+
+    #error_page  404              /404.html;
+
+    # redirect server error pages to the static page /50x.html
+    #
+    #error_page   500 502 503 504  /50x.html;
+    #location = /50x.html {
+    #    root   /usr/share/nginx/html;
+    #}
+
+    # proxy the PHP scripts to Apache listening on 127.0.0.1:80
+    #
+    #location ~ \.php$ {
+    #    proxy_pass   http://127.0.0.1;
+    #}
+
+    # pass the PHP scripts to FastCGI server listening on 127.0.0.1:9000
+    #
+    #location ~ \.php$ {
+    #    root           html;
+    #    fastcgi_pass   127.0.0.1:9000;
+    #    fastcgi_index  index.php;
+    #    fastcgi_param  SCRIPT_FILENAME  /scripts$fastcgi_script_name;
+    #    include        fastcgi_params;
+    #}
+
+    # deny access to .htaccess files, if Apache's document root
+    # concurs with nginx's one
+    #
+    #location ~ /\.ht {
+    #    deny  all;
+    #}
+}

--- a/Dockerfile.prod
+++ b/Dockerfile.prod
@@ -1,0 +1,18 @@
+FROM node:14-alpine AS builder
+
+WORKDIR /home/node/app/
+
+COPY . .
+
+RUN npm install
+RUN npm run build
+
+# In case of yarn:
+# RUN yarn install
+# RUN yarn run build
+
+FROM nginx:stable-alpine
+
+COPY ./.nginx/templates/* /etc/nginx/templates/
+
+COPY --from=builder /home/node/app/build /usr/share/nginx/html

--- a/README.md
+++ b/README.md
@@ -39,11 +39,12 @@ La aplicación está lista para ser lanzada!
 
 Revisa esta sección sobre [lanzamiento](https://facebook.github.io/create-react-app/docs/deployment) para más información.
 ## docker
+
 Puedes usar [Docker](https://docs.docker.com/get-docker/) y/o [docker-compose](https://docs.docker.com/compose/install/) para correr el proyecto.
 
-con `docker-compose` (docker-compose es una herramienta dependiente de Docker). En la raíz del proyecto puedes correr:
-
 ### Desarrollo con docker compose
+
+Con `docker-compose` (docker-compose es una herramienta dependiente de Docker). En la raíz del proyecto puedes correr:
 
 ```sh
 docker-compose up

--- a/README.md
+++ b/README.md
@@ -43,12 +43,39 @@ Puedes usar [Docker](https://docs.docker.com/get-docker/) y/o [docker-compose](h
 
 con `docker-compose` (docker-compose es una herramienta dependiente de Docker). En la raíz del proyecto puedes correr:
 
-### `docker-compose up`
+### Desarrollo con docker compose
+
+```sh
+docker-compose up
+```
 
 con Docker. En la raíz del proyecto puedes correr:
 
-### `docker build -t migala-form .`
-### `docker run -p 3000:3000 migala-form`
+```sh
+docker build -t migala-form .
+```
+
+```sh
+docker run -p 3000:3000 migala-form
+```
+
+### Builds para producción
+
+El siguiente comando construirá una imágen de contenedor con una versión
+productiva del proyecto:
+
+```sh
+docker build -t migala-form-prod -f Dockerfile.prod .
+```
+
+Para correr el contenedor:
+
+```sh
+docker run -e PORT=3000 -p 3000:3000 migala-form-prod
+```
+
+La variable de entorno `PORT` indica el el puerto de nginx. El nombre de la 
+variable se puede cambiar desde los archivos de template de nginx.
 
 ## Aprende más
 


### PR DESCRIPTION
Agregué un archivo Dockerfile.prod que permite crear builds del proyecto a través de un contenedor de Node para posteriormente agregar el build a una imágen de NGINX (servidor web) lista para producción.

Utilizar imágenes de contenedores permite montar el fomulario en el servicio en la nube de preferencia (heroku, aws, gcloud, etc...) sin mayor complicación y manteniendo la integridad del mismo. También permite la escalabilidad horizontal en caso de utilizar infraestructura propia.

El tamaño de la imagen generada es de menos de 30Mb:

![Tamaño de la imagen del contenedor](https://user-images.githubusercontent.com/32922313/142380346-402b7879-65d8-4d46-aebe-4002ef4a9437.png)

![Contenedor corriendo](https://user-images.githubusercontent.com/32922313/142380741-b5695f45-70fe-4363-9042-aabf47e2264d.png)
